### PR TITLE
Update Pangle Adapter 7909

### DIFF
--- a/Adapters/Pangle/versions.json
+++ b/Adapters/Pangle/versions.json
@@ -1,5 +1,5 @@
 {
   "mediationsdk": "9.3.0",
-  "adapter": "5.10.0",
+  "adapter": "5.11.0",
   "sdk": "7.9.0.9"
 }


### PR DESCRIPTION
- Manual configuration of GDPR information is no longer supported. Pangle will automatically read the settings from the CMP
- Enhanced error handling with the new collect signals API: PAGSdk.getBiddingToken(Context context, PAGBiddingRequest biddingRequest, PAGBidCallback bidCallback)